### PR TITLE
BUGFIX: various bugs when a line of pip show module does not contain an ':' delimited entry.

### DIFF
--- a/sbom4python/scanner.py
+++ b/sbom4python/scanner.py
@@ -68,15 +68,17 @@ class SBOMScanner:
         if self.debug:
             print(f"Process Module {module}")
         out = self.run_program(f"pip show {module}")
-        # If module not found, no metadata returned
+        # If: module not found, no metadata returned
         if len(out) > 0:
             self.metadata = {}
             for line in out:
                 entry = line.split(":")
-                # store all data after keyword
-                self.metadata[entry[0]] = (
-                    line.split(f"{entry[0]}:", 1)[1].strip().rstrip("\n")
-                )
+                # If: this line contain an non empty entry delimited by ':'
+                if ((len(entry) == 2) and
+                        (entry[1] and not (entry[1].isspace()))):
+                    # then: store all data after keyword
+                    self.metadata[entry[0]] = (
+                        line.split(f"{entry[0]}:", 1)[1].strip().rstrip("\n"))
             if self.debug:
                 print(f"Metadata for {module}\n{self.metadata}")
             self.sbom_package.initialise()


### PR DESCRIPTION
# Implemented a temporary fix for #8 
[Commit Files Diff](https://github.com/anthonyharrison/sbom4python/pull/9/commits/8c72351335b1aae346354ef303191d8db44a2837.diff)

- fix #8 

- Now, unless `sbom4python` is able to split a line of `pip show module` using `:` as a delimiter, and unless the result of this split contains **EXACTLY 2 entries**, with the second one being neither empty nor whitespaces, then the program will skip it and directly parse the next line of `pip show module` result.
- This could be further improved by adding a `dictionnary` of valid entries keywords, and checking entries of parsed lines of `pip show module` against it, skipping lines that don't contain a proper keyword.



on-behalf-of: @Red-Alert-Labs youenn.tillard@redalertlabs.com