### PR TITLE
Allow usage of python interpreter (for use in venv). Fixes #31

### DIFF
--- a/sbom4python/cli.py
+++ b/sbom4python/cli.py
@@ -75,6 +75,11 @@ def main(argv=None):
         default=False,
         help="use pip for package management",
     )
+    input_group.add_argument(
+        "--python",
+        action="store",
+        help="use specified Python interpreter for pip",
+    )
 
     output_group = parser.add_argument_group("Output")
     output_group.add_argument(
@@ -130,6 +135,7 @@ def main(argv=None):
         "debug": False,
         "format": "tag",
         "graph": "",
+        "python": "",
     }
 
     raw_args = parser.parse_args(argv[1:])
@@ -167,6 +173,7 @@ def main(argv=None):
         args["exclude_license"],
         include_service=args["include_service"],
         use_pip=args["use_pip"],
+        python_path=args["python"],
     )
 
     if len(module_name) > 0:

--- a/sbom4python/scanner.py
+++ b/sbom4python/scanner.py
@@ -10,6 +10,7 @@ import string
 import subprocess
 import sys
 import unicodedata
+from typing import Iterable
 
 if sys.version_info >= (3, 11):
     import tomllib as toml
@@ -43,6 +44,7 @@ class SBOMScanner:
         lifecycle="build",
         include_service=False,
         use_pip=False,
+        python_path:str=None
     ):
         self.record = []
         self.debug = debug
@@ -63,16 +65,21 @@ class SBOMScanner:
         self.set_lifecycle(lifecycle)
         self.metadata = {}
         self.use_pip = use_pip
+        self.python_path = pathlib.Path(python_path)
 
     def set_parent(self, module):
         self.parent = f"Python-{module}"
 
-    def run_program(self, command_line):
-        # Remove any null bytes
-        command_line = command_line.replace("\x00", "")
-        # Split command line into individual elements
-        params = command_line.split()
-        res = subprocess.run(params, capture_output=True, text=True)
+    def run_pip_cmd(self, params:Iterable[str]):
+        cmd = ["pip"]
+        if self.python_path.exists():
+            cmd.extend(("--python", str(self.python_path)))
+
+        cmd.extend(params)
+        return self.run_program(cmd)
+
+    def run_program(self, params:Iterable[str]):
+        res = subprocess.run(list(params), capture_output=True, text=True)
         return res.stdout.splitlines()
 
     def set_lifecycle(self, lifecycle):
@@ -370,7 +377,7 @@ class SBOMScanner:
     def _getpackage_metadata(self, module):
         metadata = {}
         if self.use_pip:
-            out = self.run_program(f"pip show {module}")
+            out = self.run_pip_cmd(("show", module))
             for line in out:
                 entry = line.split(":")
                 # If: this line contain an non-empty entry delimited by ':'
@@ -561,7 +568,7 @@ class SBOMScanner:
     def _get_installed_modules(self):
         modules = []
         if self.use_pip:
-            out = self.run_program("pip list")
+            out = self.run_pip_cmd(("list", ))
             if len(out) > 0:
                 # Ignore headers in output stream
                 for m in out[2:]:


### PR DESCRIPTION
This feature adds `--python` parameter to use a different python installation like *venv*.
```shell
python4sbom --python /my/venv/bin/python --system --use-pip
```
Fixes #31 