### PR TITLE
Fix: Open TOML files in binary mode as required by tomllib

### DIFF
--- a/sbom4python/scanner.py
+++ b/sbom4python/scanner.py
@@ -647,7 +647,7 @@ class SBOMScanner:
             filePath = pathlib.Path(filename)
             # Check path exists and is a valid file
             if filePath.exists() and filePath.is_file():
-                with open(filename) as file:
+                with open(filename, "rb") as file:
                     pyproject_data = toml.load(file)
                     if "project" in pyproject_data:
                         if "dependencies" in pyproject_data["project"]:
@@ -713,7 +713,7 @@ class SBOMScanner:
             filePath = pathlib.Path(filename)
             # Check path exists and is a valid file
             if filePath.exists() and filePath.is_file():
-                with open(filename) as file:
+                with open(filename, "rb") as file:
                     pylock_data = toml.load(file)
                     if "lock-version" in pylock_data:
                         if self.debug:


### PR DESCRIPTION
## Problem
   When processing pyproject.toml and poetry.lock files, sbom4python fails with:
   `TypeError: File must be opened in binary mode, e.g. use open('foo.toml', 'rb')`

   ## Root Cause
   Python's tomllib (introduced in Python 3.11) requires TOML files to be opened in binary mode, 
   but the code was opening them in text mode.

   ## Solution
   Changed file opening mode from 'r' (text) to 'rb' (binary) in two locations:
   - Line 650 in `process_pyproject()` method for pyproject.toml files
   - Line 716 in `process_pylock()` method for poetry.lock files

## Testing
Successfully tested with BentoML's pyproject.toml file that previously caused TypeError.

Test command: 
```
sbom4python -r pyproject.toml --sbom cyclonedx --format json -o output.json
```